### PR TITLE
Remove unnecessary spread, use {} as `triggerMap`

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -37,7 +37,7 @@ const MicroModal = (() => {
       this.config = { debugMode, disableScroll, openTrigger, closeTrigger, openClass, onShow, onClose, awaitCloseAnimation, awaitOpenAnimation, disableFocus }
 
       // Register click events only if pre binding eventListeners
-      if (triggers.length > 0) this.registerTriggers(...triggers)
+      if (triggers.length > 0) this.registerTriggers(triggers)
 
       // pre bind functions for event listeners
       this.onClick = this.onClick.bind(this)
@@ -49,7 +49,7 @@ const MicroModal = (() => {
      * @param  {array} triggers [Array of node elements]
      * @return {void}
      */
-    registerTriggers (...triggers) {
+    registerTriggers (triggers) {
       triggers.filter(Boolean).forEach(trigger => {
         trigger.addEventListener('click', event => this.showModal(event))
       })
@@ -140,7 +140,7 @@ const MicroModal = (() => {
 
     getFocusableNodes () {
       const nodes = this.modal.querySelectorAll(FOCUSABLE_ELEMENTS)
-      return Array(...nodes)
+      return Array.prototype.slice.call(nodes)
     }
 
     /**
@@ -208,14 +208,14 @@ const MicroModal = (() => {
   let activeModal = null
 
   /**
-   * Generates an associative array of modals and it's
+   * Generates an object containing modals and it's
    * respective triggers
    * @param  {array} triggers     An array of all triggers
    * @param  {string} triggerAttr The data-attribute which triggers the module
-   * @return {array}
+   * @return {object}
    */
   const generateTriggerMap = (triggers, triggerAttr) => {
-    const triggerMap = []
+    const triggerMap = {}
 
     triggers.forEach(trigger => {
       const targetModal = trigger.attributes[triggerAttr].value
@@ -258,7 +258,7 @@ const MicroModal = (() => {
    * Checks if triggers and their corresponding modals
    * are present in the DOM
    * @param  {array} triggers   Array of DOM nodes which have data-triggers
-   * @param  {array} triggerMap Associative array of modals and their triggers
+   * @param  {object} triggerMap Object containing modals and their triggers
    * @return {boolean}
    */
   const validateArgs = (triggers, triggerMap) => {
@@ -278,7 +278,7 @@ const MicroModal = (() => {
     const options = Object.assign({}, { openTrigger: 'data-micromodal-trigger' }, config)
 
     // Collects all the nodes with the trigger
-    const triggers = [...document.querySelectorAll(`[${ options.openTrigger }]`)]
+    const triggers = Array.prototype.slice.call(document.querySelectorAll(`[${ options.openTrigger }]`))
 
     // Makes a mappings of modals with their trigger nodes
     const triggerMap = generateTriggerMap(triggers, options.openTrigger)
@@ -288,9 +288,9 @@ const MicroModal = (() => {
 
     // For every target modal creates a new instance
     for (var key in triggerMap) {
-      let value = triggerMap[key]
+      let valueArr = triggerMap[key]
       options.targetModal = key
-      options.triggers = [...value]
+      options.triggers = valueArr
       activeModal = new Modal(options) // eslint-disable-line no-new
     }
   }


### PR DESCRIPTION
Hello. [There is a problem in IE11](https://github.com/ghosh/Micromodal/issues/49#issuecomment-424213347) which needs additional polyfilling in order to work. But I also discovered that it causes errors in IE11 even with polyfills and Babel transpilation.

I found out that polyfilling `Array.from` is actually unnecessary: the code containing it is generated by Babel transpilation, and caused by spread operators used in the code. But what I found is that spread operators can be either easily removed (in case of converting `NodeList` to `Array`), or aren't needed at all.

I also changed `triggerMap` to be an object instead of array.