### PR TITLE
Allow to pass Element itself to targetModal, not only 'id' of element

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -31,7 +31,7 @@ const MicroModal = (() => {
       debugMode = false
     }) {
       // Save a reference of the modal
-      this.modal = typeof targetModal === "string" ? document.getElementById(targetModal) : targetModal
+      this.modal = typeof targetModal === 'string' ? document.getElementById(targetModal) : targetModal
 
       // Save a reference to the passed config
       this.config = { debugMode, disableScroll, openTrigger, closeTrigger, openClass, onShow, onClose, awaitCloseAnimation, awaitOpenAnimation, disableFocus }

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -31,7 +31,7 @@ const MicroModal = (() => {
       debugMode = false
     }) {
       // Save a reference of the modal
-      this.modal = document.getElementById(targetModal)
+      this.modal = typeof targetModal === "string" ? document.getElementById(targetModal) : targetModal
 
       // Save a reference to the passed config
       this.config = { debugMode, disableScroll, openTrigger, closeTrigger, openClass, onShow, onClose, awaitCloseAnimation, awaitOpenAnimation, disableFocus }


### PR DESCRIPTION
Enables usage of library in web-components.
See https://github.com/ghosh/Micromodal/issues/65#issuecomment-654797068

![image](https://user-images.githubusercontent.com/1798101/86777918-0f081900-c05a-11ea-8951-577e27a35b05.png)
